### PR TITLE
add correct data-target attribute to carousel-indicators

### DIFF
--- a/aldryn_gallery/templates/aldryn_gallery/standard/gallery.html
+++ b/aldryn_gallery/templates/aldryn_gallery/standard/gallery.html
@@ -5,7 +5,7 @@
 {# Indicators #}
 <ol class="carousel-indicators">
     {% for slide in slides %}
-        <li data-target="#" data-slide-to="{{ forloop.counter0 }}"{% if forloop.first %} class="active"{% endif %}></li>
+        <li data-target="#js-aldryn-gallery-{{ instance.pk }}" data-slide-to="{{ forloop.counter0 }}"{% if forloop.first %} class="active"{% endif %}></li>
     {% endfor %}
 </ol>
 


### PR DESCRIPTION
add correct data-target value so indicators can be used for navigation