### PR TITLE
Gracefully default to the standard style if you can't get the parent.

### DIFF
--- a/aldryn_gallery/cms_plugins.py
+++ b/aldryn_gallery/cms_plugins.py
@@ -32,10 +32,11 @@ class GalleryChildBase(GalleryBase):
         return context
 
     def get_slide_template(self, instance, name='slide'):
-        return 'aldryn_gallery/plugins/{}/{}.html'.format(
-            getattr(instance.parent.get_plugin_instance()[0], 'style',  GalleryPlugin.STANDARD),
-            name,
-        )
+        if instance.parent is None:
+            style = GalleryPlugin.STANDARD
+        else:
+            style = getattr(instance.parent.get_plugin_instance()[0], 'style',  GalleryPlugin.STANDARD)
+        return 'aldryn_gallery/plugins/{}/{}.html'.format(style, name)
 
     def get_render_template(self, context, instance, placeholder):
         return self.get_slide_template(instance=instance)


### PR DESCRIPTION
For some reason on some sites with have a slide for which we can find the parent. As a result entering edit mode results in an error. This guards against this situation, although it should be noted that it's not a fix at all - we shouldn't ever be in this situation - just a chance to get a bit further.